### PR TITLE
requirements.txt: Add forgotten xlrd package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ ruamel.yaml==0.16.5
 ruamel.yaml.clib==0.1.2
 six==1.12.0
 wincertstore==0.2
+xlrd==1.2.0


### PR DESCRIPTION
The script cc_step_to_nwb.py requires the xlrd package for reading Excel
files.